### PR TITLE
Update connection auto detection logic

### DIFF
--- a/keyboards/laptreus/laptreus.c
+++ b/keyboards/laptreus/laptreus.c
@@ -2,12 +2,5 @@
 
 void matrix_init_kb() {
   // auto detect output on init
-  #ifdef MODULE_ADAFRUIT_BLE
-    uint8_t output = auto_detect_output();
-    if (output == OUTPUT_USB) {
-      set_output(OUTPUT_USB);
-    } else {
-      set_output(OUTPUT_BLUETOOTH);
-    }
-  #endif
+  set_output(OUTPUT_AUTO);
 }


### PR DESCRIPTION
Using the `set_output(OUTPUT_AUTO)` seemed to fix a bug where the keyboard failed to function when attempting to use it via USB rather than Bluetooth.